### PR TITLE
Automatically rename dashboard resources

### DIFF
--- a/azure/apimanagement_service/dashboards/overview/main.tf
+++ b/azure/apimanagement_service/dashboards/overview/main.tf
@@ -18,7 +18,7 @@ output "dashboard_url" {
   description = "OpenTelemetry Collector API Management Service Dashboard URL"
 }
 
-resource "lightstep_dashboard" "otel_collector_dashboard" {
+resource "lightstep_dashboard" "azure_apimanagement_service_overview" {
   project_name          = var.lightstep_project
   dashboard_name        = "API Management Service Metrics"
   dashboard_description = "Monitor API Management Service with this metrics overview dashboard."

--- a/azure/cache_redis/dashboards/overview/main.tf
+++ b/azure/cache_redis/dashboards/overview/main.tf
@@ -18,7 +18,7 @@ output "dashboard_url" {
   description = "OpenTelemetry Collector Cache Redis Dashboard URL"
 }
 
-resource "lightstep_dashboard" "otel_collector_dashboard" {
+resource "lightstep_dashboard" "azure_cache_redis_overview" {
   project_name          = var.lightstep_project
   dashboard_name        = "Cache Redis Metrics"
   dashboard_description = "[Beta] Monitor Cache Redis with this metrics overview dashboard."

--- a/azure/cdn_cdnwebapplicationfirewallpolicies/dashboards/overview/main.tf
+++ b/azure/cdn_cdnwebapplicationfirewallpolicies/dashboards/overview/main.tf
@@ -18,7 +18,7 @@ output "dashboard_url" {
   description = "OpenTelemetry Collector CDN Web Application Firewall Policies Dashboard URL"
 }
 
-resource "lightstep_dashboard" "otel_collector_dashboard" {
+resource "lightstep_dashboard" "azure_cdn_cdnwebapplicationfirewallpolicies_overview" {
   project_name          = var.lightstep_project
   dashboard_name        = "CDN Web Application Firewall Policies Metrics"
   dashboard_description = "[Beta] Monitor CDN Web Application Firewall Policies with this metrics overview dashboard."

--- a/azure/cdn_profiles/dashboards/overview/main.tf
+++ b/azure/cdn_profiles/dashboards/overview/main.tf
@@ -18,7 +18,7 @@ output "dashboard_url" {
   description = "OpenTelemetry Collector CDN Profiles Dashboard URL"
 }
 
-resource "lightstep_dashboard" "otel_collector_dashboard" {
+resource "lightstep_dashboard" "azure_cdn_profiles_overview" {
   project_name          = var.lightstep_project
   dashboard_name        = "CDN Profiles Metrics"
   dashboard_description = "[Beta] Monitor CDN Profiles with this metrics overview dashboard."

--- a/azure/cognitiveservices_accounts/dashboards/overview/main.tf
+++ b/azure/cognitiveservices_accounts/dashboards/overview/main.tf
@@ -18,7 +18,7 @@ output "dashboard_url" {
   description = "OpenTelemetry Collector Cognitive Services Accounts Dashboard URL"
 }
 
-resource "lightstep_dashboard" "otel_collector_dashboard" {
+resource "lightstep_dashboard" "azure_cognitiveservices_accounts_overview" {
   project_name          = var.lightstep_project
   dashboard_name        = "Cognitive Services Accounts Metrics"
   dashboard_description = "[Beta] Monitor Cognitive Services Accounts with this metrics overview dashboard."

--- a/azure/compute_cloudservices/dashboards/overview/main.tf
+++ b/azure/compute_cloudservices/dashboards/overview/main.tf
@@ -18,7 +18,7 @@ output "dashboard_url" {
   description = "OpenTelemetry Collector Compute Cloud Services Dashboard URL"
 }
 
-resource "lightstep_dashboard" "otel_collector_dashboard" {
+resource "lightstep_dashboard" "azure_compute_cloudservices_overview" {
   project_name          = var.lightstep_project
   dashboard_name        = "Compute Cloud Services Metrics"
   dashboard_description = "[Beta] Monitor Compute Cloud Services with this metrics overview dashboard."

--- a/azure/compute_cloudservices_roles/dashboards/overview/main.tf
+++ b/azure/compute_cloudservices_roles/dashboards/overview/main.tf
@@ -18,7 +18,7 @@ output "dashboard_url" {
   description = "OpenTelemetry Collector Compute Cloud Services Roles Dashboard URL"
 }
 
-resource "lightstep_dashboard" "otel_collector_dashboard" {
+resource "lightstep_dashboard" "azure_compute_cloudservices_roles_overview" {
   project_name          = var.lightstep_project
   dashboard_name        = "Compute Cloud Services Roles Metrics"
   dashboard_description = "[Beta] Monitor Compute Cloud Services Roles with this metrics overview dashboard."

--- a/azure/compute_disks/dashboards/overview/main.tf
+++ b/azure/compute_disks/dashboards/overview/main.tf
@@ -18,7 +18,7 @@ output "dashboard_url" {
   description = "OpenTelemetry Collector Compute Disks Dashboard URL"
 }
 
-resource "lightstep_dashboard" "otel_collector_dashboard" {
+resource "lightstep_dashboard" "azure_compute_disks_overview" {
   project_name          = var.lightstep_project
   dashboard_name        = "Compute Disks Metrics"
   dashboard_description = "Monitor Compute Disks with this metrics overview dashboard."

--- a/azure/compute_virtualmachines/dashboards/overview/main.tf
+++ b/azure/compute_virtualmachines/dashboards/overview/main.tf
@@ -18,7 +18,7 @@ output "dashboard_url" {
   description = "OpenTelemetry Collector Compute Virtual Machines Dashboard URL"
 }
 
-resource "lightstep_dashboard" "otel_collector_dashboard" {
+resource "lightstep_dashboard" "azure_compute_virtualmachines_overview" {
   project_name          = var.lightstep_project
   dashboard_name        = "Compute Virtual Machines Metrics"
   dashboard_description = "Monitor Compute Virtual Machines with this metrics overview dashboard."

--- a/azure/compute_virtualmachinescalesets/dashboards/overview/main.tf
+++ b/azure/compute_virtualmachinescalesets/dashboards/overview/main.tf
@@ -18,7 +18,7 @@ output "dashboard_url" {
   description = "OpenTelemetry Collector Compute Virtual Machine Scale Sets Dashboard URL"
 }
 
-resource "lightstep_dashboard" "otel_collector_dashboard" {
+resource "lightstep_dashboard" "azure_compute_virtualmachinescalesets_overview" {
   project_name          = var.lightstep_project
   dashboard_name        = "Compute Virtual Machine Scale Sets Metrics"
   dashboard_description = "[Beta] Monitor Compute Virtual Nachine Scale Sets with this metrics overview dashboard."

--- a/azure/compute_virtualmachinescalesets_virtualmachines/dashboards/overview/main.tf
+++ b/azure/compute_virtualmachinescalesets_virtualmachines/dashboards/overview/main.tf
@@ -18,7 +18,7 @@ output "dashboard_url" {
   description = "OpenTelemetry Collector Compute Virtual Machine Scale Sets Virtual Machines Dashboard URL"
 }
 
-resource "lightstep_dashboard" "otel_collector_dashboard" {
+resource "lightstep_dashboard" "azure_compute_virtualmachinescalesets_virtualmachines_overview" {
   project_name          = var.lightstep_project
   dashboard_name        = "Compute Virtual Machine Scale Sets Virtual Machines Metrics"
   dashboard_description = "[Beta] Monitor Compute Virtual Machine Scale Sets Virtual Machines with this metrics overview dashboard."

--- a/azure/containerinstance_containergroups/dashboards/overview/main.tf
+++ b/azure/containerinstance_containergroups/dashboards/overview/main.tf
@@ -18,7 +18,7 @@ output "dashboard_url" {
   description = "OpenTelemetry Collector Container Instance Container Groups Dashboard URL"
 }
 
-resource "lightstep_dashboard" "otel_collector_dashboard" {
+resource "lightstep_dashboard" "azure_containerinstance_containergroups_overview" {
   project_name          = var.lightstep_project
   dashboard_name        = "Container Instance Container Groups Metrics"
   dashboard_description = "[Beta] Monitor Container Instance Container Groups with this metrics overview dashboard."

--- a/azure/containerinstance_containerscalesets/dashboards/overview/main.tf
+++ b/azure/containerinstance_containerscalesets/dashboards/overview/main.tf
@@ -18,7 +18,7 @@ output "dashboard_url" {
   description = "OpenTelemetry Collector Container Instance Container Scale Sets Dashboard URL"
 }
 
-resource "lightstep_dashboard" "otel_collector_dashboard" {
+resource "lightstep_dashboard" "azure_containerinstance_containerscalesets_overview" {
   project_name          = var.lightstep_project
   dashboard_name        = "Container Instance Container Scale Sets Metrics"
   dashboard_description = "[Beta] Monitor Container Instance Container Scale Sets with this metrics overview dashboard."

--- a/azure/containerregistry_registries/dashboards/overview/main.tf
+++ b/azure/containerregistry_registries/dashboards/overview/main.tf
@@ -18,7 +18,7 @@ output "dashboard_url" {
   description = "OpenTelemetry Collector Container Registry Registries Dashboard URL"
 }
 
-resource "lightstep_dashboard" "otel_collector_dashboard" {
+resource "lightstep_dashboard" "azure_containerregistry_registries_overview" {
   project_name          = var.lightstep_project
   dashboard_name        = "Container Registry Metrics"
   dashboard_description = "Monitor Container Registry with this metrics overview dashboard."

--- a/azure/containerservice_managedclusters/dashboards/overview/main.tf
+++ b/azure/containerservice_managedclusters/dashboards/overview/main.tf
@@ -18,7 +18,7 @@ output "dashboard_url" {
   description = "OpenTelemetry Collector Container Service Managed Clusters Dashboard URL"
 }
 
-resource "lightstep_dashboard" "otel_collector_dashboard" {
+resource "lightstep_dashboard" "azure_containerservice_managedclusters_overview" {
   project_name          = var.lightstep_project
   dashboard_name        = "Container Service Managed Clusters Metrics"
   dashboard_description = "Monitor Container Service Managed Clusters with this metrics overview dashboard."

--- a/azure/dbformariadb_servers/dashboards/overview/main.tf
+++ b/azure/dbformariadb_servers/dashboards/overview/main.tf
@@ -18,7 +18,7 @@ output "dashboard_url" {
   description = "OpenTelemetry Collector MariaDB Servers Dashboard URL"
 }
 
-resource "lightstep_dashboard" "otel_collector_dashboard" {
+resource "lightstep_dashboard" "azure_dbformariadb_servers_overview" {
   project_name          = var.lightstep_project
   dashboard_name        = "MariaDB Servers Metrics"
   dashboard_description = "Monitor MariaDB Servers with this metrics overview dashboard."

--- a/azure/dbformysql_flexibleservers/dashboards/overview/main.tf
+++ b/azure/dbformysql_flexibleservers/dashboards/overview/main.tf
@@ -18,7 +18,7 @@ output "dashboard_url" {
   description = "OpenTelemetry Collector MySQL Flexible Servers Dashboard URL"
 }
 
-resource "lightstep_dashboard" "otel_collector_dashboard" {
+resource "lightstep_dashboard" "azure_dbformysql_flexibleservers_overview" {
   project_name          = var.lightstep_project
   dashboard_name        = "MySQL Flexible Servers Metrics"
   dashboard_description = "Monitor MySQL Flexible Servers with this metrics overview dashboard."

--- a/azure/dbformysql_servers/dashboards/overview/main.tf
+++ b/azure/dbformysql_servers/dashboards/overview/main.tf
@@ -18,7 +18,7 @@ output "dashboard_url" {
   description = "OpenTelemetry Collector MySQL Servers Dashboard URL"
 }
 
-resource "lightstep_dashboard" "otel_collector_dashboard" {
+resource "lightstep_dashboard" "azure_dbformysql_servers_overview" {
   project_name          = var.lightstep_project
   dashboard_name        = "MySQL Servers Metrics"
   dashboard_description = "Monitor MySQL Servers with this metrics overview dashboard."

--- a/azure/dbforpostgresql_flexibleservers/dashboards/overview/main.tf
+++ b/azure/dbforpostgresql_flexibleservers/dashboards/overview/main.tf
@@ -18,7 +18,7 @@ output "dashboard_url" {
   description = "OpenTelemetry Collector PostgreSQL Flexible Servers Dashboard URL"
 }
 
-resource "lightstep_dashboard" "otel_collector_dashboard" {
+resource "lightstep_dashboard" "azure_dbforpostgresql_flexibleservers_overview" {
   project_name          = var.lightstep_project
   dashboard_name        = "PostgreSQL Flexible Servers Metrics"
   dashboard_description = "Monitor PostgreSQL Flexible Servers with this metrics overview dashboard."

--- a/azure/dbforpostgresql_servers/dashboards/overview/main.tf
+++ b/azure/dbforpostgresql_servers/dashboards/overview/main.tf
@@ -18,7 +18,7 @@ output "dashboard_url" {
   description = "OpenTelemetry Collector PostgreSQL Servers Dashboard URL"
 }
 
-resource "lightstep_dashboard" "otel_collector_dashboard" {
+resource "lightstep_dashboard" "azure_dbforpostgresql_servers_overview" {
   project_name          = var.lightstep_project
   dashboard_name        = "PostgreSQL Servers Metrics"
   dashboard_description = "Monitor PostgreSQL Servers with this metrics overview dashboard."

--- a/azure/documentdb_cassandraclusters/dashboards/overview/main.tf
+++ b/azure/documentdb_cassandraclusters/dashboards/overview/main.tf
@@ -18,7 +18,7 @@ output "dashboard_url" {
   description = "OpenTelemetry Collector DocumentDB Cassandra Clusters Dashboard URL"
 }
 
-resource "lightstep_dashboard" "otel_collector_dashboard" {
+resource "lightstep_dashboard" "azure_documentdb_cassandraclusters_overview" {
   project_name          = var.lightstep_project
   dashboard_name        = "DocumentDB Cassandra Clusters Metrics"
   dashboard_description = "[Beta] Monitor DocumentDB Cassandra Clusters with this metrics overview dashboard."

--- a/azure/documentdb_databaseaccounts/dashboards/overview/main.tf
+++ b/azure/documentdb_databaseaccounts/dashboards/overview/main.tf
@@ -18,7 +18,7 @@ output "dashboard_url" {
   description = "OpenTelemetry Collector DocumentDB Database Accounts Dashboard URL"
 }
 
-resource "lightstep_dashboard" "otel_collector_dashboard" {
+resource "lightstep_dashboard" "azure_documentdb_databaseaccounts_overview" {
   project_name          = var.lightstep_project
   dashboard_name        = "DocumentDB Database Accounts Metrics"
   dashboard_description = "Monitor DocumentDB Database Accounts with this metrics overview dashboard."

--- a/azure/network_networkinterfaces/dashboards/overview/main.tf
+++ b/azure/network_networkinterfaces/dashboards/overview/main.tf
@@ -18,7 +18,7 @@ output "dashboard_url" {
   description = "OpenTelemetry Collector Network Interfaces Dashboard URL"
 }
 
-resource "lightstep_dashboard" "otel_collector_dashboard" {
+resource "lightstep_dashboard" "azure_network_networkinterfaces_overview" {
   project_name          = var.lightstep_project
   dashboard_name        = "Network Interfaces Metrics"
   dashboard_description = "Monitor Network Interfaces with this metrics overview dashboard."

--- a/azure/sql_managedinstances/dashboards/overview/main.tf
+++ b/azure/sql_managedinstances/dashboards/overview/main.tf
@@ -18,7 +18,7 @@ output "dashboard_url" {
   description = "OpenTelemetry Collector SQL Managed Instances Dashboard URL"
 }
 
-resource "lightstep_dashboard" "otel_collector_dashboard" {
+resource "lightstep_dashboard" "azure_sql_managedinstances_overview" {
   project_name          = var.lightstep_project
   dashboard_name        = "SQL Managed Instances Metrics"
   dashboard_description = "[Beta] Monitor SQL Managed Instances with this metrics overview dashboard."

--- a/azure/sql_servers_databases/dashboards/overview/main.tf
+++ b/azure/sql_servers_databases/dashboards/overview/main.tf
@@ -18,7 +18,7 @@ output "dashboard_url" {
   description = "OpenTelemetry Collector SQL Servers Databases Dashboard URL"
 }
 
-resource "lightstep_dashboard" "otel_collector_dashboard" {
+resource "lightstep_dashboard" "azure_sql_servers_databases_overview" {
   project_name          = var.lightstep_project
   dashboard_name        = "SQL Servers Databases Metrics"
   dashboard_description = "Monitor SQL Servers Databases with this metrics overview dashboard."

--- a/azure/sql_servers_elasticpools/dashboards/overview/main.tf
+++ b/azure/sql_servers_elasticpools/dashboards/overview/main.tf
@@ -18,7 +18,7 @@ output "dashboard_url" {
   description = "OpenTelemetry Collector Sql_servers_elasticpools Dashboard URL"
 }
 
-resource "lightstep_dashboard" "otel_collector_dashboard" {
+resource "lightstep_dashboard" "azure_sql_servers_elasticpools_overview" {
   project_name          = var.lightstep_project
   dashboard_name        = "SQL Servers Elastic Pools Metrics"
   dashboard_description = "Monitor SQL Servers Elastic Pools with this metrics overview dashboard."

--- a/azure/storage_storageaccounts/dashboards/overview/main.tf
+++ b/azure/storage_storageaccounts/dashboards/overview/main.tf
@@ -18,7 +18,7 @@ output "dashboard_url" {
   description = "OpenTelemetry Collector Storage Accounts Dashboard URL"
 }
 
-resource "lightstep_dashboard" "otel_collector_dashboard" {
+resource "lightstep_dashboard" "azure_storage_storageaccounts_overview" {
   project_name          = var.lightstep_project
   dashboard_name        = "Storage Accounts Metrics"
   dashboard_description = "Monitor Storage Accounts with this metrics overview dashboard."

--- a/azure/storage_storageaccounts_blobservices/dashboards/overview/main.tf
+++ b/azure/storage_storageaccounts_blobservices/dashboards/overview/main.tf
@@ -18,7 +18,7 @@ output "dashboard_url" {
   description = "OpenTelemetry Collector Storage Blob Services Dashboard URL"
 }
 
-resource "lightstep_dashboard" "otel_collector_dashboard" {
+resource "lightstep_dashboard" "azure_storage_storageaccounts_blobservices_overview" {
   project_name          = var.lightstep_project
   dashboard_name        = "Storage Blob Services Metrics"
   dashboard_description = "Monitor Storage Blob Services with this metrics overview dashboard."

--- a/azure/storage_storageaccounts_fileservices/dashboards/overview/main.tf
+++ b/azure/storage_storageaccounts_fileservices/dashboards/overview/main.tf
@@ -18,7 +18,7 @@ output "dashboard_url" {
   description = "OpenTelemetry Collector Storage File Services Dashboard URL"
 }
 
-resource "lightstep_dashboard" "otel_collector_dashboard" {
+resource "lightstep_dashboard" "azure_storage_storageaccounts_fileservices_overview" {
   project_name          = var.lightstep_project
   dashboard_name        = "Storage File Services Metrics"
   dashboard_description = "Monitor Storage File Services with this metrics overview dashboard."

--- a/azure/storage_storageaccounts_objectreplicationpolicies/dashboards/overview/main.tf
+++ b/azure/storage_storageaccounts_objectreplicationpolicies/dashboards/overview/main.tf
@@ -18,7 +18,7 @@ output "dashboard_url" {
   description = "OpenTelemetry Collector Storage Object Replication Policies Dashboard URL"
 }
 
-resource "lightstep_dashboard" "otel_collector_dashboard" {
+resource "lightstep_dashboard" "azure_storage_storageaccounts_objectreplicationpolicies_overview" {
   project_name          = var.lightstep_project
   dashboard_name        = "Storage Object Replication Policies Metrics"
   dashboard_description = "[Beta] Monitor Storage Object Replication Policies with this metrics overview dashboard."

--- a/azure/storage_storageaccounts_queueservices/dashboards/overview/main.tf
+++ b/azure/storage_storageaccounts_queueservices/dashboards/overview/main.tf
@@ -18,7 +18,7 @@ output "dashboard_url" {
   description = "OpenTelemetry Collector Storage Queue Services Dashboard URL"
 }
 
-resource "lightstep_dashboard" "otel_collector_dashboard" {
+resource "lightstep_dashboard" "azure_storage_storageaccounts_queueservices_overview" {
   project_name          = var.lightstep_project
   dashboard_name        = "Storage Queue Services Metrics"
   dashboard_description = "Monitor Storage Queue Services with this metrics overview dashboard."

--- a/azure/storage_storageaccounts_storagetasks/dashboards/overview/main.tf
+++ b/azure/storage_storageaccounts_storagetasks/dashboards/overview/main.tf
@@ -18,7 +18,7 @@ output "dashboard_url" {
   description = "OpenTelemetry Collector Storage Tasks Dashboard URL"
 }
 
-resource "lightstep_dashboard" "otel_collector_dashboard" {
+resource "lightstep_dashboard" "azure_storage_storageaccounts_storagetasks_overview" {
   project_name          = var.lightstep_project
   dashboard_name        = "Storage Tasks Metrics"
   dashboard_description = "[Beta] Monitor Storage Tasks with this metrics overview dashboard."

--- a/azure/storage_storageaccounts_tableservices/dashboards/overview/main.tf
+++ b/azure/storage_storageaccounts_tableservices/dashboards/overview/main.tf
@@ -18,7 +18,7 @@ output "dashboard_url" {
   description = "OpenTelemetry Collector Storage Table Services Dashboard URL"
 }
 
-resource "lightstep_dashboard" "otel_collector_dashboard" {
+resource "lightstep_dashboard" "azure_storage_storageaccounts_tableservices_overview" {
   project_name          = var.lightstep_project
   dashboard_name        = "Storage Table Services Metrics"
   dashboard_description = "Monitor Storage Table Services with this metrics overview dashboard."

--- a/collector/kong/dashboards/overview/main.tf
+++ b/collector/kong/dashboards/overview/main.tf
@@ -18,9 +18,9 @@ output "dashboard_url" {
   description = "OpenTelemetry Collector Kong Dashboard URL"
 }
 
-resource "lightstep_dashboard" "otel_collector_dashboard" {
-  project_name   = var.lightstep_project
-  dashboard_name = "Kong Metrics"
+resource "lightstep_dashboard" "collector_kong_overview" {
+  project_name          = var.lightstep_project
+  dashboard_name        = "Kong Metrics"
   dashboard_description = "Monitor Kong with this metrics overview dashboard."
 
   chart {

--- a/collector/nats/dashboards/server/main.tf
+++ b/collector/nats/dashboards/server/main.tf
@@ -18,7 +18,7 @@ output "dashboard_url" {
   description = "OpenTelemetry Collector NATS Server Dashboard URL"
 }
 
-resource "lightstep_dashboard" "otel_collector_dashboard" {
+resource "lightstep_dashboard" "collector_nats_server" {
   project_name          = var.lightstep_project
   dashboard_name        = "NATS Server"
   dashboard_description = "A real-time Nats server monitoring dashboard providing insights into server performance and message traffic."

--- a/collector/pulsar/dashboards/overview/main.tf
+++ b/collector/pulsar/dashboards/overview/main.tf
@@ -8,11 +8,11 @@ terraform {
   required_version = ">= v1.0.11"
 }
 
-resource "lightstep_dashboard" "otel_collector_pulsar_dashboard" {
-  project_name          = var.cloud_observability_project
+resource "lightstep_dashboard" "collector_pulsar_overview" {
+  project_name          = var.lightstep_project
   dashboard_name        = "OpenTelemetry Pulsar & Dashboard"
   dashboard_description = "Monitor Pulsar and metrics with this summary dashboard."
-  
+
   chart {
     name = "CPU Time Spent"
     rank = "0"

--- a/scripts/rename_dash_resources.py
+++ b/scripts/rename_dash_resources.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+"""
+A script to rename Terraform resources based on directory structure.
+This uses directory structure to align to {platform}_{service}.
+Code expects it is run within platform directories such as collector or azure.
+
+Give a specific structure:
+    1. {service}/dashboards/{x}/main.tf: Resource anmed as "{cwd}_{service}_{x}".
+    2. {service}/dashboards/main.tf: Resource named as "{cwd}_{service}".
+
+Where {cwd} is the name of te current working directory.
+"""
+
+import os
+import re
+
+def rename_resources_in_file(filepath: str, prefix: str):
+    """Renames resources in given Terraform file.
+
+    Args:
+        filepath (str): The path to the Terraform file.
+        prefix (str): Prefix to use in the new resource name.
+
+    Returns:
+        None
+    """
+    with open(filepath, 'r') as file:
+        content = file.read()
+
+    # extract attributes from path
+    parts = os.path.normpath(filepath).split(os.sep)
+
+    # id the service
+    service = parts[-4] if len(parts) >= 4 else ''
+    x = parts[-2] if len(parts) >= 3 and parts[-1] == "main.tf" and parts[-2] != "dashboards" else ''
+
+    new_resource_name = f"{prefix}_{service}_{x}" if x else f"{prefix}_{service}"
+
+    # replace resource name in content with regex
+    content = re.sub(
+            r'resource \"lightstep_dashboard\" \"(.*?)\" {',
+            f'resource "lightstep_dashboard" "{new_resource_name}" {{',
+            content
+    )
+
+    # write modified content back to file
+    with open(filepath,'w') as file:
+        file.write(content)
+
+def main():
+    """Main function."""
+    root_directory = '.' # start in current
+    prefix = os.path.basename(os.getcwd())
+
+    # iterate directories and files
+    for subdir, _, files in os.walk(root_directory):
+        for file in files:
+            if file == 'main.tf':
+                full_path = os.path.join(subdir, file)
+                rename_resources_in_file(full_path, prefix)
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
This renames dashboard resources using a Python script that is committed with the changes. The script follows a naming scheme that will result in unique, descriptive, and consistent Terraform dashboard names.

Though the naming scheme is selected deliberately and no changes are specifically contemplated at this time, the script makes it straightforward to vary the naming scheme if we face requirements to use a different naming scheme.