### PR TITLE
Fix Cloud Observability names

### DIFF
--- a/azure/README.md
+++ b/azure/README.md
@@ -3,12 +3,12 @@
 
 The OTel Collector has a variety of [third party receivers](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/master/receiver) that provide integration with a wide variety of metric sources.
 
-Please note that not all metrics receivers available for the OpenTelemetry Collector have been tested by Lightstep Observability, and there may be bugs or unexpected issues in using these contributed receivers with Lightstep Observability metrics. File any issues with the appropriate OpenTelemetry community.
+Please note that not all metrics receivers available for the OpenTelemetry Collector have been tested by ServiceNow Cloud Observability Observability, and there may be bugs or unexpected issues in using these contributed receivers with ServiceNow Cloud Observability Observability metrics. File any issues with the appropriate OpenTelemetry community.
 {: .callout}
 
 ## Prerequisites for local installation
 
-You must have a Lightstep Observability [access token](/docs/create-and-manage-access-tokens) for the project to report metrics to.
+You must have a ServiceNow Cloud Observability Observability [access token](/docs/create-and-manage-access-tokens) for the project to report metrics to.
 Also you must have Azure account credentials.
 
 ## Running the Example
@@ -39,7 +39,7 @@ Detailed description of available [Azure metrics per service](https://learn.micr
 
 Collector Azure Monitor receiver has to be configured to capture required Azure resources, [configuration description](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/azuremonitorreceiver#configuration).
 
-The following example configuration collects metrics from Azure and send them to Lightstep Observability:
+The following example configuration collects metrics from Azure and send them to ServiceNow Cloud Observability Observability:
 
 ```yaml
 receivers:

--- a/azure/apimanagement_service/dashboards/overview/main.tf
+++ b/azure/apimanagement_service/dashboards/overview/main.tf
@@ -9,7 +9,7 @@ terraform {
 }
 
 variable "lightstep_project" {
-  description = "Lightstep Project Name"
+  description = "ServiceNow Cloud Observability Project Name"
   type        = string
 }
 

--- a/azure/compute_disks/dashboards/overview/main.tf
+++ b/azure/compute_disks/dashboards/overview/main.tf
@@ -9,7 +9,7 @@ terraform {
 }
 
 variable "lightstep_project" {
-  description = "Lightstep Project Name"
+  description = "ServiceNow Cloud Observability Project Name"
   type        = string
 }
 

--- a/azure/compute_virtualmachines/dashboards/overview/main.tf
+++ b/azure/compute_virtualmachines/dashboards/overview/main.tf
@@ -9,7 +9,7 @@ terraform {
 }
 
 variable "lightstep_project" {
-  description = "Lightstep Project Name"
+  description = "ServiceNow Cloud Observability Project Name"
   type        = string
 }
 

--- a/azure/containerregistry_registries/dashboards/overview/main.tf
+++ b/azure/containerregistry_registries/dashboards/overview/main.tf
@@ -9,7 +9,7 @@ terraform {
 }
 
 variable "lightstep_project" {
-  description = "Lightstep Project Name"
+  description = "ServiceNow Cloud Observability Project Name"
   type        = string
 }
 

--- a/azure/containerservice_managedclusters/dashboards/overview/main.tf
+++ b/azure/containerservice_managedclusters/dashboards/overview/main.tf
@@ -9,7 +9,7 @@ terraform {
 }
 
 variable "lightstep_project" {
-  description = "Lightstep Project Name"
+  description = "ServiceNow Cloud Observability Project Name"
   type        = string
 }
 

--- a/azure/dbformariadb_servers/dashboards/overview/main.tf
+++ b/azure/dbformariadb_servers/dashboards/overview/main.tf
@@ -9,7 +9,7 @@ terraform {
 }
 
 variable "lightstep_project" {
-  description = "Lightstep Project Name"
+  description = "ServiceNow Cloud Observability Project Name"
   type        = string
 }
 

--- a/azure/dbformysql_flexibleservers/dashboards/overview/main.tf
+++ b/azure/dbformysql_flexibleservers/dashboards/overview/main.tf
@@ -9,7 +9,7 @@ terraform {
 }
 
 variable "lightstep_project" {
-  description = "Lightstep Project Name"
+  description = "ServiceNow Cloud Observability Project Name"
   type        = string
 }
 

--- a/azure/dbformysql_servers/dashboards/overview/main.tf
+++ b/azure/dbformysql_servers/dashboards/overview/main.tf
@@ -9,7 +9,7 @@ terraform {
 }
 
 variable "lightstep_project" {
-  description = "Lightstep Project Name"
+  description = "ServiceNow Cloud Observability Project Name"
   type        = string
 }
 

--- a/azure/dbforpostgresql_flexibleservers/dashboards/overview/main.tf
+++ b/azure/dbforpostgresql_flexibleservers/dashboards/overview/main.tf
@@ -9,7 +9,7 @@ terraform {
 }
 
 variable "lightstep_project" {
-  description = "Lightstep Project Name"
+  description = "ServiceNow Cloud Observability Project Name"
   type        = string
 }
 

--- a/azure/dbforpostgresql_servers/dashboards/overview/main.tf
+++ b/azure/dbforpostgresql_servers/dashboards/overview/main.tf
@@ -9,7 +9,7 @@ terraform {
 }
 
 variable "lightstep_project" {
-  description = "Lightstep Project Name"
+  description = "ServiceNow Cloud Observability Project Name"
   type        = string
 }
 

--- a/azure/documentdb_cassandraclusters/dashboards/overview/main.tf
+++ b/azure/documentdb_cassandraclusters/dashboards/overview/main.tf
@@ -9,7 +9,7 @@ terraform {
 }
 
 variable "lightstep_project" {
-  description = "Lightstep Project Name"
+  description = "ServiceNow Cloud Observability Project Name"
   type        = string
 }
 

--- a/azure/documentdb_databaseaccounts/dashboards/overview/main.tf
+++ b/azure/documentdb_databaseaccounts/dashboards/overview/main.tf
@@ -9,7 +9,7 @@ terraform {
 }
 
 variable "lightstep_project" {
-  description = "Lightstep Project Name"
+  description = "ServiceNow Cloud Observability Project Name"
   type        = string
 }
 

--- a/azure/network_networkinterfaces/dashboards/overview/main.tf
+++ b/azure/network_networkinterfaces/dashboards/overview/main.tf
@@ -9,7 +9,7 @@ terraform {
 }
 
 variable "lightstep_project" {
-  description = "Lightstep Project Name"
+  description = "ServiceNow Cloud Observability Project Name"
   type        = string
 }
 

--- a/azure/sql_managedinstances/dashboards/overview/main.tf
+++ b/azure/sql_managedinstances/dashboards/overview/main.tf
@@ -9,7 +9,7 @@ terraform {
 }
 
 variable "lightstep_project" {
-  description = "Lightstep Project Name"
+  description = "ServiceNow Cloud Observability Project Name"
   type        = string
 }
 

--- a/azure/sql_servers_databases/dashboards/overview/main.tf
+++ b/azure/sql_servers_databases/dashboards/overview/main.tf
@@ -9,7 +9,7 @@ terraform {
 }
 
 variable "lightstep_project" {
-  description = "Lightstep Project Name"
+  description = "ServiceNow Cloud Observability Project Name"
   type        = string
 }
 

--- a/azure/sql_servers_elasticpools/dashboards/overview/main.tf
+++ b/azure/sql_servers_elasticpools/dashboards/overview/main.tf
@@ -9,7 +9,7 @@ terraform {
 }
 
 variable "lightstep_project" {
-  description = "Lightstep Project Name"
+  description = "ServiceNow Cloud Observability Project Name"
   type        = string
 }
 

--- a/azure/storage_storageaccounts/dashboards/overview/main.tf
+++ b/azure/storage_storageaccounts/dashboards/overview/main.tf
@@ -9,7 +9,7 @@ terraform {
 }
 
 variable "lightstep_project" {
-  description = "Lightstep Project Name"
+  description = "ServiceNow Cloud Observability Project Name"
   type        = string
 }
 

--- a/azure/storage_storageaccounts_blobservices/dashboards/overview/main.tf
+++ b/azure/storage_storageaccounts_blobservices/dashboards/overview/main.tf
@@ -9,7 +9,7 @@ terraform {
 }
 
 variable "lightstep_project" {
-  description = "Lightstep Project Name"
+  description = "ServiceNow Cloud Observability Project Name"
   type        = string
 }
 

--- a/azure/storage_storageaccounts_fileservices/dashboards/overview/main.tf
+++ b/azure/storage_storageaccounts_fileservices/dashboards/overview/main.tf
@@ -9,7 +9,7 @@ terraform {
 }
 
 variable "lightstep_project" {
-  description = "Lightstep Project Name"
+  description = "ServiceNow Cloud Observability Project Name"
   type        = string
 }
 

--- a/azure/storage_storageaccounts_objectreplicationpolicies/dashboards/overview/main.tf
+++ b/azure/storage_storageaccounts_objectreplicationpolicies/dashboards/overview/main.tf
@@ -9,7 +9,7 @@ terraform {
 }
 
 variable "lightstep_project" {
-  description = "Lightstep Project Name"
+  description = "ServiceNow Cloud Observability Project Name"
   type        = string
 }
 

--- a/azure/storage_storageaccounts_queueservices/dashboards/overview/main.tf
+++ b/azure/storage_storageaccounts_queueservices/dashboards/overview/main.tf
@@ -9,7 +9,7 @@ terraform {
 }
 
 variable "lightstep_project" {
-  description = "Lightstep Project Name"
+  description = "ServiceNow Cloud Observability Project Name"
   type        = string
 }
 

--- a/azure/storage_storageaccounts_storagetasks/dashboards/overview/main.tf
+++ b/azure/storage_storageaccounts_storagetasks/dashboards/overview/main.tf
@@ -9,7 +9,7 @@ terraform {
 }
 
 variable "lightstep_project" {
-  description = "Lightstep Project Name"
+  description = "ServiceNow Cloud Observability Project Name"
   type        = string
 }
 

--- a/azure/storage_storageaccounts_tableservices/dashboards/overview/main.tf
+++ b/azure/storage_storageaccounts_tableservices/dashboards/overview/main.tf
@@ -9,7 +9,7 @@ terraform {
 }
 
 variable "lightstep_project" {
-  description = "Lightstep Project Name"
+  description = "ServiceNow Cloud Observability Project Name"
   type        = string
 }
 

--- a/collector/confluentplatform/dashboards/overview/variables.tf
+++ b/collector/confluentplatform/dashboards/overview/variables.tf
@@ -1,4 +1,4 @@
 variable "lightstep_project" {
-  description = "Name of Lightstep project"
+  description = "Name of ServiceNow Cloud Observability project"
   type        = string
 }

--- a/collector/ghosttunnel/examples/compose/README.md
+++ b/collector/ghosttunnel/examples/compose/README.md
@@ -1,4 +1,4 @@
-# Monitor Ghostunnel with the OpenTelemetry Collector for Lightstep
+# Monitor Ghostunnel with the OpenTelemetry Collector for ServiceNow Cloud Observability
 
 ## Overview
 

--- a/collector/hikaricp/dashboards/overview/main.tf
+++ b/collector/hikaricp/dashboards/overview/main.tf
@@ -9,7 +9,7 @@ terraform {
 }
 
 resource "lightstep_dashboard" "otel_collector_hikaricp_dashboard" {
-  project_name          = var.cloud_observability_project
+  project_name          = var.lightstep_project
   dashboard_name        = "HikariCP and System Metrics Dashboard"
   dashboard_description = "Monitor HikariCP and System Metrics."
 

--- a/collector/hikaricp/dashboards/overview/variables.tf
+++ b/collector/hikaricp/dashboards/overview/variables.tf
@@ -1,4 +1,4 @@
 variable "lightstep_project" {
-  description = "Name of Lightstep project"
+  description = "Name of ServiceNow Cloud Observability project"
   type        = string
 }

--- a/collector/hikaricp/examples/compose/README.md
+++ b/collector/hikaricp/examples/compose/README.md
@@ -8,7 +8,7 @@
 
 * Docker
 * Docker Compose
-* A Lightstep Observability [access token][ls-docs-access-token]
+* A ServiceNow Cloud Observability Observability [access token][ls-docs-access-token]
 
 ### Java application with Spring framework and a Postgres database
 
@@ -28,7 +28,7 @@ Example structure:
 
 ## How to run the example
 
-* Export your Lightstep access token
+* Export your ServiceNow Cloud Observability access token
   ```
   export LS_ACCESS_TOKEN=<YOUR_TOKEN>
   ```
@@ -41,7 +41,7 @@ Example structure:
   docker-compose down`
   ```
 
-### Explore Metrics in Lightstep
+### Explore Metrics in ServiceNow Cloud Observability
 
 See the [Hikaricp Telemetry Docs][hikaricp-prometheus-docs] for comprehensive documentation on metrics emitted and the [dashboard documentation][ls-docs-dashboards] for more details.
 
@@ -67,7 +67,7 @@ spring.datasource.hikari.maximum-pool-size=5
 
 management.endpoints.web.exposure.include=*
 management.endpoints.web.exposure.include=prometheus,health,info,metric
- 
+
 management.health.probes.enabled=true
 management.endpoint.health.show-details=always
 ```

--- a/collector/hive/dashboards/overview/main.tf
+++ b/collector/hive/dashboards/overview/main.tf
@@ -9,7 +9,7 @@ terraform {
 }
 
 resource "lightstep_dashboard" "otel_collector_hive_dashboard" {
-  project_name          = var.cloud_observability_project
+  project_name          = var.lightstep_project
   dashboard_name        = "OpenTelemetry Hive JMX Metrics Dashboard"
   dashboard_description = "Monitor Hive JMX metrics with this overview dashboard."
 

--- a/collector/hive/dashboards/overview/variables.tf
+++ b/collector/hive/dashboards/overview/variables.tf
@@ -1,4 +1,4 @@
 variable "lightstep_project" {
-  description = "Name of Lightstep project"
+  description = "Name of ServiceNow Cloud Observability project"
   type        = string
 }

--- a/collector/kong/dashboards/overview/main.tf
+++ b/collector/kong/dashboards/overview/main.tf
@@ -9,7 +9,7 @@ terraform {
 }
 
 variable "lightstep_project" {
-  description = "Lightstep Project Name"
+  description = "ServiceNow Cloud Observability Project Name"
   type        = string
 }
 

--- a/collector/pulsar/examples/compose/README.md
+++ b/collector/pulsar/examples/compose/README.md
@@ -2,29 +2,29 @@
 
 ## Overview
 
- Pulsar natively exposes a Prometheus endpoint and the OpenTelemetry Collector has a [Prometheus receiver][otel-prom-receiver] that can be used to scrape its Prometheus endpoint. This directory contains an example showing how to configure Pulsar and the Collector to send metrics to Lightstep Observability.
+ Pulsar natively exposes a Prometheus endpoint and the OpenTelemetry Collector has a [Prometheus receiver][otel-prom-receiver] that can be used to scrape its Prometheus endpoint. This directory contains an example showing how to configure Pulsar and the Collector to send metrics to ServiceNow Cloud Observability Observability.
 
 ## Prerequisites
 
 * Docker
 * Docker Compose
-* A Lightstep Observability [access token][ls-docs-access-token]
+* A ServiceNow Cloud Observability Observability [access token][ls-docs-access-token]
 
 ## How to run the example
 
-* Export your Lightstep access token
-  
+* Export your ServiceNow Cloud Observability access token
+
   ```sh
   export LS_ACCESS_TOKEN=<YOUR_TOKEN>
   ```
 
 * Run the docker compose example
-  
+
   ```sh
   docker-compose up -d
   ```
 
-### Explore Metrics in Lightstep
+### Explore Metrics in ServiceNow Cloud Observability
 
 See the [Pulsar Telemetry Docs][pulsar-docs-telemetry] for comprehensive documentation on metrics emitted and the [dashboard documentation][ls-docs-dashboards] for more details.
 

--- a/collector/solr/dashboards/overview/variables.tf
+++ b/collector/solr/dashboards/overview/variables.tf
@@ -1,4 +1,4 @@
 variable "lightstep_project" {
-  description = "Name of Lightstep project"
+  description = "Name of ServiceNow Cloud Observability project"
   type        = string
 }


### PR DESCRIPTION
Unaddressed naming changes that relate to the previously fixed variable names. While these changes are technically in code and thus almost all of them don't fall into the scope of the intended rebranded, they do provide some clarity. They are the description fields for variables in Terraform modules.