### PR TITLE
Improve Kong example

### DIFF
--- a/collector/kong/examples/compose/app/client.py
+++ b/collector/kong/examples/compose/app/client.py
@@ -4,14 +4,15 @@
 #
 #   export DESTINATION_HOST=my-host-address
 #   python client.py
-
 import os
 import time
+import random
 import requests
+import string
 
 gateway_port = 8000
 
-def send_requests(url: str):
+def send_get_request(url: str):
     try:
         res = requests.get(url)
         print(f"Request to {url}, status: {res.status_code} got {len(res.content)} bytes")
@@ -22,12 +23,49 @@ def send_requests(url: str):
             except ValueError:
                 print('No json body in response')
     except Exception as e:
-        print(f"Request to {url} failed {e}")
+        print(f"GET Request to {url} failed {e}")
+
+
+def send_post_request(url: str):
+    # random 5 character string to spice up the payload
+    rstr = lambda n: ''.join(random.choice(string.ascii_lowercase) for i in range(n))
+    data = {
+        "id": random.randint(1, 100),
+        "name": f"my number is {rstr(5)}",
+        "value": random.randint(1, 100),
+    }
+    try:
+        res = requests.post(url, json=data)
+        print(f"POST request to {url}, status: {res.status_code} got {len(res.content)} bytes")
+
+        if res.status_code >= 400:
+            try:
+                json_response = res.json()
+                print("Message: ", json_response.get('message', 'Kong provided no message'))
+            except ValueError:
+                print('No json body in response')
+    except Exception as e:
+        print(f"POST request to {url} failed {e}")
+
 
 if __name__ == "__main__":
+    time.sleep(15)
+    # this should be the name of the API Gateway service
     host = os.getenv("DESTINATION_HOST", "localhost")
+    random_int = random.randint(89, 189)
+    bytes_target = f"http://{host}:{gateway_port}/bytes/{random_int}"
+    get_target = f"http://{host}:{gateway_port}/get"
+    post_target = f"http://{host}:{gateway_port}/post"
+    anything_target = f"http://{host}:{gateway_port}/anything"
 
-    target = f"http://{host}:{gateway_port}/httpbin/bytes/111"
     while True:
-        send_requests(target)
-        time.sleep(1)
+        send_get_request(bytes_target)
+        time.sleep(0.33)
+        send_get_request(get_target)
+        time.sleep(0.33)
+        send_post_request(post_target)
+        time.sleep(0.33)
+        send_get_request(anything_target)
+        time.sleep(0.33)
+        send_post_request(anything_target)
+        time.sleep(0.33)

--- a/collector/kong/examples/compose/collector.yml
+++ b/collector/kong/examples/compose/collector.yml
@@ -13,6 +13,16 @@ receivers:
         - job_name: "otel-collector"
           static_configs:
             - targets: ["kong-gateway:8001"]
+  httpcheck:
+    targets: 
+      - endpoint: http://kong-gateway:8000/get
+        method: GET
+      - endpoint: http://kong-gateway:8000/post
+        method: POST
+      - endpoint: http://kong-gateway:8000/anything
+        method: GET
+      - endpoint: http://kong-gateway:8000/anything
+        method: POST
   filelog:
     include: ["/var/log/kong/kong.log"]
     start_at: "beginning"

--- a/collector/kong/examples/compose/docker-compose.yml
+++ b/collector/kong/examples/compose/docker-compose.yml
@@ -12,10 +12,10 @@ services:
           - KONG_PORTAL="on kong reload exit"
         ports:
           - '8000:8000'
-          - '8001:8001'
-          - '8002:8002'
           - '8443:8443'
+          - '8001:8001'
           - '8444:8444'
+          - '8002:8002'
           - '8445:8445'
           - '8003:8003'
           - '8004:8004'
@@ -24,9 +24,13 @@ services:
           - ./kong.conf:/etc/kong/kong.conf:rw
           - ./kong.yml:/etc/kong/kong.yml:rw
           - ./logs/kong:/var/log/kong
+    httpbin:
+        image: kennethreitz/httpbin
+        container_name: httpbin
+        ports:
+          - '8080:80'
     client:
         build: ./app
-          # container_name: client
         environment:
           - DESTINATION_HOST=kong-gateway
           - COLLECTOR_HOST=otel-collector

--- a/collector/kong/examples/compose/kong.yml
+++ b/collector/kong/examples/compose/kong.yml
@@ -4,21 +4,72 @@ _transform: true
 services:
   # configure servicenow_service like in app/client.py
   - name: httpbin_service
-    host: httpbin.org
+    host: httpbin_container
+    port: 8080
+    url: http://httpbin # to httpbin service
     protocol: http
-    url: http://httpbin.org
     routes:
-      - name: httpbin_route
+      - name: httpbin_route_bytes
         paths:
-          - /httpbin
+          - /bytes
+        strip_path: false
         methods:
           - GET
-    plugins:
-      - name: file-log
-        config:
-          path: /var/log/kong/kong.log
-      - name: opentelemetry
-        config:
-          endpoint: http://otel-collector:4318/v1/traces
-          resource_attributes:
-            service.name: httpbin_service
+        plugins:
+          - name: file-log
+            config:
+              path: /var/log/kong/kong.log
+          - name: opentelemetry
+            config:
+              endpoint: http://otel-collector:4318/v1/traces
+              resource_attributes:
+                route.name: httpbin_route_bytes
+          - name: prometheus
+            config:
+              status_code_metrics: true
+              latency_metrics: true
+              bandwidth_metrics: true
+              upstream_health_metrics: true
+      - name: httpbin_route_post
+        paths:
+          - /post
+        strip_path: false
+        methods:
+          - POST
+        plugins:
+          - name: file-log
+            config:
+              path: /var/log/kong/kong.log
+          - name: opentelemetry
+            config:
+              endpoint: http://otel-collector:4318/v1/traces
+              resource_attributes:
+                route.name: httpbin_route_post
+          - name: prometheus
+            config:
+              status_code_metrics: true
+              latency_metrics: true
+              bandwidth_metrics: true
+              upstream_health_metrics: true
+      - name: httpbin_route_anything
+        paths:
+          - /anything
+        strip_path: false
+        methods:
+          - GET
+          - POST
+        plugins:
+          - name: file-log
+            config:
+              path: /var/log/kong/kong.log
+          - name: opentelemetry
+            config:
+              endpoint: http://otel-collector:4318/v1/traces
+              resource_attributes:
+                route.name: httpbin_route_anything
+          - name: prometheus
+            config:
+              status_code_metrics: true
+              latency_metrics: true
+              bandwidth_metrics: true
+              upstream_health_metrics: true


### PR DESCRIPTION
## Description
What does this PR do?

__Updates the Kong example:__
- Configure telemetry route-by-route instead of service level
- Add multiple routes for illustration
- Serve upstream service for the gateway from httpbin container (not public demo site)
- Add httpcheck receiver targets for synthetic check on these routes